### PR TITLE
don't force column order in test

### DIFF
--- a/tests/testthat/test-01-integration.R
+++ b/tests/testthat/test-01-integration.R
@@ -176,8 +176,8 @@ test_that("Conversion of whole 2D mesh to integration points", {
 
   expect_s3_class(ips, "sf")
   expect_equal(
-    colnames(ips),
-    c("weight", ".block", "geometry", ".block_origin")
+    sort(colnames(ips)),
+    sort(c("weight", ".block", "geometry", ".block_origin"))
   )
   expect_equal(sum(ips$weight), 64.58135, tolerance = lowtol)
 


### PR DESCRIPTION
this is needed for a clean check after changes in sf, motivated by https://github.com/r-spatial/sf/issues/2568 and developed in https://github.com/r-spatial/sf/pull/2584